### PR TITLE
fixed newline behavior in Mods state

### DIFF
--- a/states/Mods.lua
+++ b/states/Mods.lua
@@ -113,8 +113,8 @@ end
 
 local function truncateText(inputText, maxWidth)
 	local beforeNewline = inputText:match("^(.-)\n")
-    if beforeNewline then
-        inputText = beforeNewline
+	if beforeNewline then
+		inputText = beforeNewline
 	end
 	if love.graphics.getFont():getWidth(inputText) <= maxWidth then
 		return inputText

--- a/states/Mods.lua
+++ b/states/Mods.lua
@@ -112,6 +112,10 @@ local function renderModConfig(mod)
 end
 
 local function truncateText(inputText, maxWidth)
+	local beforeNewline = inputText:match("^(.-)\n")
+    if beforeNewline then
+        inputText = beforeNewline
+	end
 	if love.graphics.getFont():getWidth(inputText) <= maxWidth then
 		return inputText
 	end


### PR DESCRIPTION
truncateText() now ignores anything that comes after a newline character