### PR TITLE
Fix mod list size when ImGui isn't drawn to a canvas

### DIFF
--- a/states/Mods.lua
+++ b/states/Mods.lua
@@ -230,11 +230,10 @@ st:setBgDraw(function(self)
     love.graphics.rectangle('fill', 0, 0, 600, 360)
 end)
 
-local windowScale = 2
-local windowWidth = 600 * windowScale
-local windowHeight = 360 * windowScale
-
 st:setFgDraw(function(self)
+    local windowWidth = imgui.canvasScale and (project.res.x * imgui.canvasScale) or love.graphics.getWidth()
+    local windowHeight = imgui.canvasScale and (project.res.y * imgui.canvasScale) or love.graphics.getHeight()
+
     helpers.SetNextWindowPos(0, 0)
     helpers.SetNextWindowSize(windowWidth, windowHeight)
     --												423
@@ -245,26 +244,26 @@ st:setFgDraw(function(self)
     imgui.SetWindowFontScale(1)
     imgui.Separator()
 
-    imgui.BeginChild_Str("mod_list_and_config", imgui.ImVec2_Float(windowWidth, 320 * windowScale), 0)
+    imgui.BeginChild_Str("mod_list_and_config", imgui.ImVec2_Float(windowWidth, windowHeight - 80), 0)
 
     imgui.Columns(2, "main", true)
     imgui.SetColumnWidth(imgui.GetColumnIndex(), windowWidth * 0.6)
 
     -- start drawing mod boxes
-    imgui.BeginChild_Str("mod_list", imgui.ImVec2_Float(550 * windowScale, 320 * windowScale), 0)
+    imgui.BeginChild_Str("mod_list", imgui.ImVec2_Float(550 / 600 * windowWidth, windowHeight - 80), 0)
 
     for _, modID in pairs(self.sortedIDs) do
         local mod = mods[modID]
         local childWidth = windowWidth * 0.59
-        local childHeight = 42 * windowScale -- just enough to fit the mod icon
+        local childHeight = 42 * 2 -- just enough to fit the mod icon
         imgui.BeginChild_Str("mod_" .. mod.id, imgui.ImVec2_Float(childWidth, childHeight), 1)
 
         imgui.Columns(2, "mod_details_" .. mod.id, true)
 
         -- mod icon
         imgui.SetColumnWidth(imgui.GetColumnIndex(), childWidth * 0.227)
-        local imageSizeX = 73 * windowScale
-        local imageSizeY = 33 * windowScale
+        local imageSizeX = 73 * 2
+        local imageSizeY = 33 * 2
         imgui.Image((modIcons[mod.id] or modIcons.unknown), imgui.ImVec2_Float(imageSizeX, imageSizeY))
         imgui.NextColumn()
 

--- a/states/Mods.lua
+++ b/states/Mods.lua
@@ -261,7 +261,7 @@ st:setFgDraw(function(self)
         imgui.Columns(2, "mod_details_" .. mod.id, true)
 
         -- mod icon
-        imgui.SetColumnWidth(imgui.GetColumnIndex(), childWidth * 0.227)
+        imgui.SetColumnWidth(imgui.GetColumnIndex(), 82 * 2)
         local imageSizeX = 73 * 2
         local imageSizeY = 33 * 2
         imgui.Image((modIcons[mod.id] or modIcons.unknown), imgui.ImVec2_Float(imageSizeX, imageSizeY))


### PR DESCRIPTION
pretty much just a fix for the imgui scale fix mod, this shouldn't change anything when that mod is not installed/enabled