### PR TITLE
Fix for Beta 1.2.1

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -1,0 +1,2 @@
+mod.config.modMenuGuiTheme = helpers.InputBool("Menu Gui", mod.config.modMenuGuiTheme)
+imgui.SetItemTooltip("Uses the Beatblock Plus theme for the mods menu")

--- a/lovely/mod-loader.toml
+++ b/lovely/mod-loader.toml
@@ -62,16 +62,9 @@ pattern = '''
 function basestate.new(filename,name)
   name = name or filename
   basestate.states[name] = love.filesystem.load("states/" .. filename .. ".lua") -- this is a bad idea
-  log("made state ".. name)
-end
 '''
 position = "at"
 payload = '''
-function basestate.new(filename, name)
-	name = name or filename
-	basestate.fromPath(name, "states/" .. filename .. ".lua")
-end
-
 function basestate.fromPath(name, path)
 	local source = path or ("states/" .. name .. ".lua")
 	local errormsg
@@ -82,6 +75,10 @@ function basestate.fromPath(name, path)
 		print("[BB+] made state " .. name)
 	end
 end
+
+function basestate.new(filename, name)
+	name = name or filename
+	basestate.fromPath(name, "states/" .. filename .. ".lua")
 '''
 match_indent = true
 

--- a/lovely/mod-loader.toml
+++ b/lovely/mod-loader.toml
@@ -79,7 +79,7 @@ function basestate.fromPath(name, path)
 	if errormsg then
 		print("[BB+] couldn't load state " .. name .. ". Error: " .. errormsg)
 	else
-		print("[BB+] made state " .. name)
+		-- print("[BB+] made state " .. name) -- double logging for the same thing, since print in the patch is different in bb main and bb beta
 	end
 end
 '''

--- a/lovely/mod-loader.toml
+++ b/lovely/mod-loader.toml
@@ -54,7 +54,7 @@ position = "before"
 payload = '''bbp.loader.loadMods()'''
 match_indent = true
 
-# handle error and allow custom path 1.2.0a
+# handle error and allow custom path
 [[patches]]
 [patches.pattern]
 target = "lib/basestate.lua"
@@ -62,16 +62,9 @@ pattern = '''
 function basestate.new(filename,name)
   name = name or filename
   basestate.states[name] = love.filesystem.load("states/" .. filename .. ".lua") -- this is a bad idea
-  print("made state ".. name)
-end
 '''
 position = "at"
 payload = '''
-function basestate.new(filename, name)
-	name = name or filename
-	basestate.fromPath(name, "states/" .. filename .. ".lua")
-end
-
 function basestate.fromPath(name, path)
 	local source = path or ("states/" .. name .. ".lua")
 	local errormsg
@@ -80,29 +73,6 @@ function basestate.fromPath(name, path)
 		print("[BB+] couldn't load state " .. name .. ". Error: " .. errormsg)
 	else
 		-- print("[BB+] made state " .. name) -- double logging for the same thing, since print in the patch is different in bb main and bb beta
-	end
-end
-'''
-match_indent = true
-# handle error and allow custom path 1.2.1 beta
-[[patches]]
-[patches.pattern]
-target = "lib/basestate.lua"
-pattern = '''
-function basestate.new(filename,name)
-  name = name or filename
-  basestate.states[name] = love.filesystem.load("states/" .. filename .. ".lua") -- this is a bad idea
-'''
-position = "at"
-payload = '''
-function basestate.fromPath(name, path)
-	local source = path or ("states/" .. name .. ".lua")
-	local errormsg
-	basestate.states[name], errormsg = love.filesystem.load(source)
-	if errormsg then
-		print("[BB+] couldn't load state " .. name .. ". Error: " .. errormsg)
-	else
-		print("[BB+] made state " .. name)
 	end
 end
 

--- a/lovely/mod-loader.toml
+++ b/lovely/mod-loader.toml
@@ -62,7 +62,7 @@ pattern = '''
 function basestate.new(filename,name)
   name = name or filename
   basestate.states[name] = love.filesystem.load("states/" .. filename .. ".lua") -- this is a bad idea
-  print("made state ".. name)
+  log("made state ".. name)
 end
 '''
 position = "at"

--- a/lovely/mod-loader.toml
+++ b/lovely/mod-loader.toml
@@ -54,7 +54,37 @@ position = "before"
 payload = '''bbp.loader.loadMods()'''
 match_indent = true
 
-# handle error and allow custom path
+# handle error and allow custom path 1.2.0a
+[[patches]]
+[patches.pattern]
+target = "lib/basestate.lua"
+pattern = '''
+function basestate.new(filename,name)
+  name = name or filename
+  basestate.states[name] = love.filesystem.load("states/" .. filename .. ".lua") -- this is a bad idea
+  print("made state ".. name)
+end
+'''
+position = "at"
+payload = '''
+function basestate.new(filename, name)
+	name = name or filename
+	basestate.fromPath(name, "states/" .. filename .. ".lua")
+end
+
+function basestate.fromPath(name, path)
+	local source = path or ("states/" .. name .. ".lua")
+	local errormsg
+	basestate.states[name], errormsg = love.filesystem.load(source)
+	if errormsg then
+		print("[BB+] couldn't load state " .. name .. ". Error: " .. errormsg)
+	else
+		print("[BB+] made state " .. name)
+	end
+end
+'''
+match_indent = true
+# handle error and allow custom path 1.2.1 beta
 [[patches]]
 [patches.pattern]
 target = "lib/basestate.lua"

--- a/mod.json
+++ b/mod.json
@@ -4,5 +4,7 @@
     "author": "BeatblockTools",
     "description": "Mod loader for Beatblock",
     "version": "1.4.1",
-    "config": []
+    "config": {
+		"modMenuGuiTheme": true
+	}
 }

--- a/states/Mods.lua
+++ b/states/Mods.lua
@@ -170,7 +170,7 @@ st:setFgDraw(function(self)
 	helpers.SetNextWindowSize(windowWidth, windowHeight)
 	--												423
 	local appliedBBPTheme = false -- The following config may change mid draw call
-	if bbp.loader.mods["beatblock-plus"].config.modMenuGuiTheme then
+	if mod.config.modMenuGuiTheme then
 		bbp.gui.pushStyle()
 		appliedBBPTheme = true
 	end

--- a/states/Mods.lua
+++ b/states/Mods.lua
@@ -169,7 +169,11 @@ st:setFgDraw(function(self)
 	helpers.SetNextWindowPos(0, 0)
 	helpers.SetNextWindowSize(windowWidth, windowHeight)
 	--												423
-	bbp.gui.pushStyle()
+	local appliedBBPTheme = false -- The following config may change mid draw call
+	if bbp.loader.mods["beatblock-plus"].config.modMenuGuiTheme then
+		bbp.gui.pushStyle()
+		appliedBBPTheme = true
+	end
 	imgui.Begin("Mods", true, 295) -- notitlebar, noresize, nomove, nocollapse, nobackground, nosavedsettings
 
 	imgui.SetWindowFontScale(2)
@@ -240,7 +244,9 @@ st:setFgDraw(function(self)
 	end
 
 	imgui.End()
-	bbp.gui.popStyle()
+	if appliedBBPTheme then
+		bbp.gui.popStyle()
+	end
 end)
 
 return st


### PR DESCRIPTION
- readjusted patch pattern to no longer fail in the beta version, where all print calls got replaced with log calls
- no longer printing the bbp print for creating a state, as such is already being done in bb: and exactly that line of code is different in bb main and bb beta; trying to patch that line without regex is going to lead to failed patches, and regex doesnt seem to be worth it