### PR TITLE
fixed entity loading

### DIFF
--- a/bbp/loader.lua
+++ b/bbp/loader.lua
@@ -257,18 +257,18 @@ function loader.loadMods() -- loads mod data, assets, mod icons etc.
 
 		-- load states
 		bbp.utils.loopFiles({}, mod.path .. "/states", function(_, path, fileName)
-			print("[BB+] injecting state " .. path .. "...")
 			bs.fromPath(fileName, path)
 			if bs.states[fileName] then
+				print("[BB+] injecting state " .. path .. "...")
 				setModChunkEnvironment(bs.states[fileName], mod)
 			end
 		end)
 
 		-- load entities
 		bbp.utils.loopFiles({}, mod.path .. "/entities", function(_, path, fileName)
-			print("[BB+] injecting entity " .. path .. "...")
 			local chunk = love.filesystem.load(path .. fileName)
 			if chunk then
+				print("[BB+] injecting entity " .. path .. "...")
 				em.entities[fileName] = setModChunkEnvironment(chunk, mod)()
 			end
 		end)

--- a/bbp/loader.lua
+++ b/bbp/loader.lua
@@ -266,7 +266,7 @@ function loader.loadMods() -- loads mod data, assets, mod icons etc.
 
 		-- load entities
 		bbp.utils.loopFiles({}, mod.path .. "/entities", function(_, path, fileName)
-			local chunk = love.filesystem.load(path .. fileName)
+			local chunk = love.filesystem.load(path)
 			if chunk then
 				print("[BB+] injecting entity " .. path .. "...")
 				em.entities[fileName] = setModChunkEnvironment(chunk, mod)()


### PR DESCRIPTION
moved logs so they only fire when successful
fixed entity loading (file path was invalid before)