### PR TITLE
Enabled mods count and force restart

### DIFF
--- a/bbp/loader.lua
+++ b/bbp/loader.lua
@@ -148,6 +148,7 @@ end
 
 function loader.loadMods() -- loads mod data, assets, mod icons etc.
 	loader.mods = {}
+	loader.activeMods = {}
 
 	-- TODO: remove this later due to deprecation
 	mods = loader.mods
@@ -230,6 +231,8 @@ function loader.loadMods() -- loads mod data, assets, mod icons etc.
 		if mod.enabled == nil then
 			mod.enabled = true
 		end
+
+		loader.activeMods[mod.id] = mod.enabled or nil -- not including disabled mods
 
 		-- load mod config if it exists
 		if love.filesystem.getInfo(mod.path .. "/config.json", 'file') then

--- a/bbp/utils.lua
+++ b/bbp/utils.lua
@@ -18,6 +18,17 @@ function utils.printTable(table, title, indent)
 	end
 end
 
+-- Counts the real amount of entries for all types of tables
+function utils.countTable(tbl)
+	local count = 0
+
+	for _, _ in pairs(tbl) do
+		count = count + 1
+	end
+
+	return count
+end
+
 -- Moves the source directory to the target directory, and deletes the source directory
 function utils.moveDirectory(source, target)
 	love.filesystem.createDirectory(target)
@@ -138,7 +149,7 @@ function utils.getLovelyInjectorWarnings()
 		if item:match("%.log$") then
 			local path = lovelyLogsPath .. "/" .. item
 			local info = love.filesystem.getInfo(path)
-			
+
 			if info and info.modtime > newestTime then
 				newestTime = info.modtime
 				logPath = path

--- a/states/Mods.lua
+++ b/states/Mods.lua
@@ -103,8 +103,11 @@ local function getEnabledModsAmount()
 end
 
 st.loadMainMenu = function(self)
-	if getActiveModsAmount() ~= getEnabledModsAmount() or self.requiresRestart then
-		openPopup("leave with changes prompt")
+	if self.requiresRestart then
+		openPopup("leave with irreversible changes")
+		return
+	elseif getActiveModsAmount() ~= getEnabledModsAmount() then
+		openPopup("leave with reversible changes")
 		return
 	end
 	cs = bs.load('Menu')
@@ -488,16 +491,34 @@ st:setFgDraw(function(self)
 		imgui.EndPopup()
 	end
 
-	if imgui.BeginPopupModal("leave with changes prompt", nil, popupFlags) then
+	if imgui.BeginPopupModal("leave with irreversible changes", nil, popupFlags) then
 		if imgui.IsKeyChordPressed(655) and not imgui.IsWindowHovered() then
 			imgui.CloseCurrentPopup()
 		end
 
-		if self.requiresRestart then
-			imgui.Text("You have made irreversible changes that require a restart.\nPlease restart the game.\nYou cannot prevent this restart with your options in the mod menu.")
-		else
-			imgui.Text("You have made changes that require a restart.\nPlease restart the game or revert your changes.")
+		imgui.Text("You have made irreversible changes that require a restart.\nPlease restart the game.\nYou cannot prevent this restart with your options in the mod menu.")
+
+		imgui.Separator()
+
+		if imgui.Button("Yes, restart now") then
+			BBP_doRestart = true
 		end
+
+		imgui.SameLine()
+		if imgui.Button("No, return to mod menu") then
+			imgui.CloseCurrentPopup()
+		end
+
+		imgui.SetItemDefaultFocus()
+		imgui.EndPopup()
+	end
+
+	if imgui.BeginPopupModal("leave with reversible changes", nil, popupFlags) then
+		if imgui.IsKeyChordPressed(655) and not imgui.IsWindowHovered() then
+			imgui.CloseCurrentPopup()
+		end
+
+		imgui.Text("You have made changes that require a restart.\nPlease restart the game or revert your changes.")
 
 		imgui.Separator()
 

--- a/states/Mods.lua
+++ b/states/Mods.lua
@@ -80,24 +80,30 @@ local function renderModConfig(self, mod)
 	end
 end
 
--- I don't know if there is a way without this
-local function getModCount(tbl)
+local function getModAmount()
+	return utils.countTable(bbp.mods)
+end
+local function getActiveModsAmount()
 	local count = 0
-	local active = 0
-	local enabled = 0
 
-	for _, mod in pairs(tbl) do
-		count = count + 1
-		if mod.enabled then enabled = enabled + 1 end
-		if bbp.loader.activeMods[mod.id] then active = active + 1 end
+	for _, mod in pairs(bbp.mods) do
+		if bbp.loader.activeMods[mod.id] then count = count + 1 end
 	end
 
-	return active, enabled, count
+	return count
+end
+local function getEnabledModsAmount()
+	local count = 0
+
+	for _, mod in pairs(bbp.mods) do
+		if mod.enabled then count = count + 1 end
+	end
+
+	return count
 end
 
 st.loadMainMenu = function(self)
-	local active, enabled = getModCount(bbp.mods)
-	if active ~= enabled or self.requiresRestart then
+	if getActiveModsAmount() ~= getEnabledModsAmount() or self.requiresRestart then
 		openPopup("leave with changes prompt")
 		return
 	end
@@ -221,9 +227,8 @@ st:setFgDraw(function(self)
 	imgui.Begin("Mods", true, 295) -- notitlebar, noresize, nomove, nocollapse, nobackground, nosavedsettings
 
 	-- we can choose between showing the amount of active or enabled mods here
-	local _, enabled, count = getModCount(bbp.mods)
 	imgui.SetWindowFontScale(2)
-	imgui.Text("Mods: " .. tostring(enabled) .. "/" .. tostring(count))
+	imgui.Text("Mods: " .. tostring(getEnabledModsAmount()) .. "/" .. tostring(getModAmount()))
 	imgui.SameLine(200)
 	imgui.Text("To install a mod, drag and drop the zip file into this menu.")
 	imgui.SetWindowFontScale(1)

--- a/states/Mods.lua
+++ b/states/Mods.lua
@@ -104,7 +104,7 @@ end
 local function hasReversibleChanges()
 	for _, mod in pairs(bbp.mods) do
 		-- convert to boolean because bbp.loader.activeMods is either true or nil
-		if (mod.enabled and true or false) ~= (bbp.loader.activeMods[mod.id] and true or false) then
+		if mod.enabled ~= (bbp.loader.activeMods[mod.id] or false) then
 			return true
 		end
 	end

--- a/states/Mods.lua
+++ b/states/Mods.lua
@@ -103,7 +103,10 @@ local function getEnabledModsAmount()
 end
 local function hasReversibleChanges()
 	for _, mod in pairs(bbp.mods) do
-		if mod.enabled ~= bbp.loader.activeMods[mod.id] then return true end
+		-- convert to boolean because bbp.loader.activeMods is either true or nil
+		if (mod.enabled and true or false) ~= (bbp.loader.activeMods[mod.id] and true or false) then
+			return true
+		end
 	end
 	return false
 end

--- a/states/Mods.lua
+++ b/states/Mods.lua
@@ -83,7 +83,7 @@ end
 local function getModAmount()
 	return bbp.utils.countTable(bbp.mods)
 end
-local function getActiveModsAmount()
+local function getActiveModsAmount() -- unused
 	local count = 0
 
 	for _, mod in pairs(bbp.mods) do
@@ -101,12 +101,18 @@ local function getEnabledModsAmount()
 
 	return count
 end
+local function hasReversibleChanges()
+	for _, mod in pairs(bbp.mods) do
+		if mod.enabled ~= bbp.loader.activeMods[mod.id] then return true end
+	end
+	return false
+end
 
 st.loadMainMenu = function(self)
 	if self.requiresRestart then
 		openPopup("leave with irreversible changes")
 		return
-	elseif getActiveModsAmount() ~= getEnabledModsAmount() then
+	elseif hasReversibleChanges() then
 		openPopup("leave with reversible changes")
 		return
 	end

--- a/states/Mods.lua
+++ b/states/Mods.lua
@@ -81,7 +81,7 @@ local function renderModConfig(self, mod)
 end
 
 local function getModAmount()
-	return utils.countTable(bbp.mods)
+	return bbp.utils.countTable(bbp.mods)
 end
 local function getActiveModsAmount()
 	local count = 0

--- a/states/Mods.lua
+++ b/states/Mods.lua
@@ -46,19 +46,19 @@ local function renderModConfig(self, mod)
 	if imgui.Button("Reset Config to Default") then
 		openPopup("reset config confirmation", {name = mod.name, path = mod.path, id = mod.id})
 	end
-	
+
 	if mod.id ~= "beatblock-plus" then
 		imgui.SameLine()
 		if imgui.Button("Delete Mod") then
 			openPopup("delete mod confirmation", {name = mod.name, path = mod.path, id = mod.id})
 		end
 	end
-	
+
 	if imgui.Button("Save Changes") then
 		self.savedConfigDisplayTimer = love.timer.getTime()
 		bbp.utils.saveConfig(mod.id)
 	end
-	
+
 	-- display some text next to the button for one second, so that the user knows that it worked
 	if self.savedConfigDisplayTimer then
 		if love.timer.getTime() - self.savedConfigDisplayTimer > 1 then
@@ -68,7 +68,7 @@ local function renderModConfig(self, mod)
 			imgui.Text("Saved!")
 		end
 	end
-	
+
 	imgui.Separator()
 
 	-- if the mod has a config.lua file, use that to render the config gui
@@ -81,17 +81,26 @@ local function renderModConfig(self, mod)
 end
 
 -- I don't know if there is a way without this
-local function countTable(tbl)
+local function getModCount(tbl)
 	local count = 0
+	local active = 0
+	local enabled = 0
 
-	for _, _ in pairs(tbl) do
+	for _, mod in pairs(tbl) do
 		count = count + 1
+		if mod.enabled then enabled = enabled + 1 end
+		if bbp.loader.activeMods[mod.id] then active = active + 1 end
 	end
 
-	return count
+	return active, enabled, count
 end
 
 st.loadMainMenu = function(self)
+	local active, enabled = getModCount(bbp.mods)
+	if active ~= enabled or self.requiresRestart then
+		openPopup("leave with changes prompt")
+		return
+	end
 	cs = bs.load('Menu')
 	self.menuMusicManager:clearOnBeatHooks()
 	cs.menuMusicManager = self.menuMusicManager
@@ -134,7 +143,7 @@ function st:filedropped(file)
 	if love.filesystem.mount(path, "draganddrop") then
 		local modsPath = "Mods/"
 		local modFolder = findModFolder("draganddrop")
-		
+
 		if not modFolder then
 			log("Error: couldn't find mod.json in zip file: " .. path, "BBP")
 			openPopup("error: no mod.json found")
@@ -153,6 +162,7 @@ function st:filedropped(file)
 		love.filesystem.createDirectory(fullPath)
 		helpers.recursiveFolderCopy(fullPath, "draganddrop".."/"..modFolder)
 		local modData = dpf.loadJson(fullPath.."/".."mod.json")
+		self.requireRestart = true
 		openPopup("new mod added", modData)
 		love.filesystem.unmount(path)
 	else
@@ -210,8 +220,10 @@ st:setFgDraw(function(self)
 	end
 	imgui.Begin("Mods", true, 295) -- notitlebar, noresize, nomove, nocollapse, nobackground, nosavedsettings
 
+	-- we can choose between showing the amount of active or enabled mods here
+	local _, enabled, count = getModCount(bbp.mods)
 	imgui.SetWindowFontScale(2)
-	imgui.Text("Mods: " .. countTable(bbp.mods))
+	imgui.Text("Mods: " .. tostring(enabled) .. "/" .. tostring(count))
 	imgui.SameLine(200)
 	imgui.Text("To install a mod, drag and drop the zip file into this menu.")
 	imgui.SetWindowFontScale(1)
@@ -306,7 +318,7 @@ st:setFgDraw(function(self)
 		if imgui.Button("OK") then
 			imgui.CloseCurrentPopup()
 		end
-		
+
 		imgui.SetItemDefaultFocus()
 	end
 
@@ -352,7 +364,7 @@ st:setFgDraw(function(self)
 
 	if imgui.BeginPopupModal("new mod added", nil, popupFlags) then
 		popupBody("The following mod has been added successfully: " ..
-				self.popupData.name .. " (" .. self.popupData.version .. ") by " .. self.popupData.author 
+				self.popupData.name .. " (" .. self.popupData.version .. ") by " .. self.popupData.author
 				.."\nRestart the game for the mod to take effect.")
 		imgui.EndPopup()
 	end
@@ -374,7 +386,7 @@ st:setFgDraw(function(self)
 			end
 
 			dpf.saveJson(self.popupData.configPath, mod.config)
-			
+
 			local success = love.filesystem.remove(self.popupData.configPath)
 			if success then
 				bbp.mods[self.popupData.id].config = helpers.copy(bbp.mods[self.popupData.id].defaultConfig)
@@ -388,7 +400,7 @@ st:setFgDraw(function(self)
 		if imgui.Button("No") then
 			imgui.CloseCurrentPopup()
 		end
-		
+
 		imgui.SetItemDefaultFocus()
 		imgui.EndPopup()
 	end
@@ -422,6 +434,7 @@ st:setFgDraw(function(self)
 		if imgui.Button("Yes") then
 			bbp.utils.deleteDirectory(self.popupData.path)
 			if not love.filesystem.getInfo(self.popupData.path) then
+				self.requireRestart = true
 				openPopupNextFrame(self, "successfully deleted mod", self.popupData)
 			else
 				openPopupNextFrame(self, "error: failed to delete mod", self.popupData)
@@ -432,7 +445,7 @@ st:setFgDraw(function(self)
 		if imgui.Button("No") then
 			imgui.CloseCurrentPopup()
 		end
-		
+
 		imgui.SetItemDefaultFocus()
 		imgui.EndPopup()
 	end
@@ -465,7 +478,33 @@ st:setFgDraw(function(self)
 		if imgui.Button("No") then
 			imgui.CloseCurrentPopup()
 		end
-		
+
+		imgui.SetItemDefaultFocus()
+		imgui.EndPopup()
+	end
+
+	if imgui.BeginPopupModal("leave with changes prompt", nil, popupFlags) then
+		if imgui.IsKeyChordPressed(655) and not imgui.IsWindowHovered() then
+			imgui.CloseCurrentPopup()
+		end
+
+		if self.requiresRestart then
+			imgui.Text("You have made irreversible changes that require a restart.\nPlease restart the game.\nYou cannot prevent this restart with your options in the mod menu.")
+		else
+			imgui.Text("You have made changes that require a restart.\nPlease restart the game or revert your changes.")
+		end
+
+		imgui.Separator()
+
+		if imgui.Button("Yes, restart now") then
+			BBP_doRestart = true
+		end
+
+		imgui.SameLine()
+		if imgui.Button("No, return to mod menu") then
+			imgui.CloseCurrentPopup()
+		end
+
 		imgui.SetItemDefaultFocus()
 		imgui.EndPopup()
 	end


### PR DESCRIPTION
Generally
- Shows enabled mod count
- Forces restart on changes requiring a restart, like enabling/disabling a mod or adding/deleting a mod

Specifically
- Starting to actively differentiate between active and enabled mods
- Specified the general local `countTable` function to `getModCount` (speaking of which, maybe a `bbp.utils.countTable` func would be nice (speaking as the modder of utilitools, which has that function))
- Added the `bbp.loader.activeMods` set(!) for all active mods, disabled mods are not included
- Added `cs.requireRestart` for irreversible mod changes that require a restart
- Added a new popup `leave with changes prompt`